### PR TITLE
Remove dependency on 3rd party repo

### DIFF
--- a/.github/workflows/sys-on-push-onboarding-tf.yml
+++ b/.github/workflows/sys-on-push-onboarding-tf.yml
@@ -52,11 +52,8 @@ jobs:
           terraform_wrapper: false
 
       - name: 'Setup jq'
-        uses: dcarbone/install-jq-action@v1.0.1
-        with:
-          version: '1.6'
-          force: false
-
+        run: sudo apt update && sudo apt install -y jq
+        
       - name: 'prepare naming from subscription and resource group'
         id: naming
         run: |


### PR DESCRIPTION
Current workflow is relying on untrusted repo which may be used to steal secrets.
Having already established OS dependencies, we can use a single-line step to replace the dependency. 