### PR TITLE
Supported Domains to be kept as per JIRA DDCCGW-739 on UAT environment 

### DIFF
--- a/scripts/tests/folder_mandatory_files.py
+++ b/scripts/tests/folder_mandatory_files.py
@@ -9,7 +9,7 @@ def test_folder_mandatory_files(country_folder):
 
     # Testing folder structure
     for domain in ofiles.keys():
-        assert domain in ('DCC','DDCC','DIVOC','ICAO','SHC','IPS-PILGRIMAGE','DICVP','PH4H'), 'Invalid domain: '+domain
+        assert domain in ('DCC','IPS-PILGRIMAGE','DICVP','PH4H'), 'Invalid domain: '+domain
 
         assert ('TLS', 'TLS.pem') in ofiles[domain], f'TLS cert is missing in domain {domain}'
         assert ('TLS', 'CA.pem') in ofiles[domain], f'TLS/CA cert is missing in domain {domain}'

--- a/scripts/tests/groups_domains.py
+++ b/scripts/tests/groups_domains.py
@@ -10,4 +10,4 @@ def test_valid_domain(cert):
 
     domain = cert.pathinfo.get('domain')
     assert domain, 'Certificate at incorrect location'
-    assert domain.upper() in ('DCC','DDCC','DIVOC','ICAO','SHC','IPS-PILGRIMAGE','DICVP','PH4H'), 'Invalid domain: ' + domain
+    assert domain.upper() in ('DCC','IPS-PILGRIMAGE','DICVP','PH4H'), 'Invalid domain: ' + domain


### PR DESCRIPTION
Supported Domains to be kept: DCC, IPS-PILGRIMAGE, DICVP PH4H as per JIRA DDCCGW-739 on UAT environment , other domains will be cleaned up.

Supported domains to keep on UAT domains :
DCC, IPS-PILGRIMAGE, DICVP, PH4H