### PR TITLE
Enable deca hajj support

### DIFF
--- a/scripts/sign.sh
+++ b/scripts/sign.sh
@@ -68,6 +68,8 @@ declare -A DIRTOUSAGE=(
   [CSCA]="TA"
   [sca]="TA"
   [SCA]="TA"
+  [deca]="TA"
+  [DECA]="TA"
 )
 
 

--- a/scripts/signing/sign-json.sh
+++ b/scripts/signing/sign-json.sh
@@ -63,6 +63,8 @@ declare -A DIRTOUSAGE=(
   [CSCA]="TA"
   [sca]="TA"
   [SCA]="TA"
+  [deca]="TA"
+  [DECA]="TA"
 )
 EXCLUDEFROMSIGNING=("CA")
 

--- a/scripts/tests/extended_key_usage.py
+++ b/scripts/tests/extended_key_usage.py
@@ -8,7 +8,8 @@ def test_extended_key_usages(cert):
     """Extended key usage for TLS and UP certs must be set"""
     if cert.pathinfo.get('group').upper() == 'SCA'\
     or cert.pathinfo.get('group').upper() == 'UP'\
-    or cert.pathinfo.get('group').upper() == 'TLS' and cert.pathinfo.get('filename').upper().startswith('CA'):
+    or cert.pathinfo.get('group').upper() == 'TLS' and cert.pathinfo.get('filename').upper().startswith('CA') \
+    or cert.pathinfo.get('group').upper() == 'DECA':
         #pytest.skip(reason='CA/SCA or UP certs do not require extended key usage')
         return # Pass: CA/SCA or UP certs do not require extended key usage
 

--- a/scripts/tests/groups_domains.py
+++ b/scripts/tests/groups_domains.py
@@ -3,7 +3,7 @@ def test_valid_group(cert):
     'The group in the path name must be valid'
     group = cert.pathinfo.get('group')
     assert group, 'Certificate at incorrect location'
-    assert group.upper() in ('UP', 'SCA', 'TLS'), 'Invalid group: ' + group
+    assert group.upper() in ('UP', 'SCA', 'TLS', 'DECA'), 'Invalid group: ' + group
 
 def test_valid_domain(cert):
     'The domain in the path name must be valid'

--- a/scripts/tests/validity_range.py
+++ b/scripts/tests/validity_range.py
@@ -9,7 +9,8 @@ def test_validity_range(cert):
     '''
     validity = cert.x509.not_valid_after - cert.x509.not_valid_before
     
-    if cert.pathinfo.get('group').upper() == 'SCA':
+    if cert.pathinfo.get('group').upper() == 'SCA' \
+        or cert.pathinfo.get('group').upper() == 'DECA':
         min_years, max_years = 2, 4
     elif cert.pathinfo.get('group').upper() == 'TLS' \
         and cert.pathinfo.get('filename').upper().startswith('CA'):         


### PR DESCRIPTION
Enabled DECA Hajj support. 

Modified below scripts  to enable DECA support for Hajj.
scripts/sign.sh
scripts/signing/sign-json.sh


scripts/tests/extended_key_usage.py
scripts/tests/groups_domains.py
scripts/tests/validity_range.py 